### PR TITLE
Update python_version 3.13 phase 1 and 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PostgreSQL
 
-Publisher: Splunk \
-Connector Version: 2.0.19 \
-Product Vendor: PostgreSQL \
-Product Name: PostgreSQL \
+Publisher: Splunk <br>
+Connector Version: 2.0.19 <br>
+Product Vendor: PostgreSQL <br>
+Product Name: PostgreSQL <br>
 Minimum Product Version: 6.2.1
 
 This app supports investigative actions against a PostgreSQL database
@@ -41,16 +41,16 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[run query](#action-run-query) - Run a query against a table or tables in the database \
-[list columns](#action-list-columns) - List the columns of a table \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[run query](#action-run-query) - Run a query against a table or tables in the database <br>
+[list columns](#action-list-columns) - List the columns of a table <br>
 [list tables](#action-list-tables) - List the tables in the database
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -65,7 +65,7 @@ No Output
 
 Run a query against a table or tables in the database
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **False**
 
 It is recommended to use the <b>format_vars</b> parameter when applicable. For example, if you wanted to find a specific IP, you could set the <b>query</b> to a formatted string, like "select * from my_hosts where ip = %s" (note the use of %s), and set <b>format_vars</b> to the IP address. This will ensure the inputs are safely sanitized and avoid SQL injection attacks. Regardless of the type of input it's expecting, the only format specifier which should be used is %s.<br>Setting <b>no_commit</b> will make it so the App does not commit any changes made to the database (so you can ensure it's a read only query).<br><br>The <b>format_vars</b> parameter accepts a comma seperated list. You can escape commas by surrounding them in double quotes, and escape double quotes with a backslash. Assuming you have a list of values for the format vars, you can employ this code in your playbooks to properly format it into a string:<br> <code>format_vars_str = ','.join(['"{}"'.format(str(x).replace('\\\\', '\\\\\\\\').replace('"', '\\\\"')) for x in format_vars_list])</code>.
@@ -97,7 +97,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List the columns of a table
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -168,7 +168,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List the tables in the database
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Describes the structure of a table in the database by displaying information about its columns. The only tables which it will be able to query for must have a name composed of only alphanumeric characters + '\_' and '$'.

--- a/postgresql.json
+++ b/postgresql.json
@@ -634,5 +634,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/postgresql.json
+++ b/postgresql.json
@@ -20,7 +20,7 @@
     "latest_tested_versions": [
         "PostgreSQL v8.4.20"
     ],
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "configuration": {
         "host": {
             "description": "Hostname or IP address",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved e0006 issue related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 1 and 2
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase1and2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase1and2)