### PR TITLE
fix: enforce PostgreSQL TLS verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: PostgreSQL
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **password** | required | password | Password |
 **database** | required | string | Database |
 **other** | optional | string | JSON Object of other libpq connection parameters |
+**verify_server_cert** | optional | boolean | Verify the PostgreSQL server certificate and hostname |
+**ssl_root_cert** | optional | string | Path to a PEM file containing trusted certificate authority certificates. When omitted, libpq uses its default root certificate file |
 
 ### Supported Actions
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/postgresql.json
+++ b/postgresql.json
@@ -50,6 +50,17 @@
             "description": "JSON Object of other libpq connection parameters",
             "data_type": "string",
             "order": 4
+        },
+        "verify_server_cert": {
+            "description": "Verify the PostgreSQL server certificate and hostname",
+            "data_type": "boolean",
+            "default": true,
+            "order": 5
+        },
+        "ssl_root_cert": {
+            "description": "Path to a PEM file containing trusted certificate authority certificates. When omitted, libpq uses its default root certificate file",
+            "data_type": "string",
+            "order": 6
         }
     },
     "actions": [

--- a/postgresql.json
+++ b/postgresql.json
@@ -9,7 +9,7 @@
     "product_name": "PostgreSQL",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "2.0.20",
     "utctime_updated": "2025-09-05T16:19:44.038323Z",
     "package_name": "phantom_postgresql",

--- a/postgresql_connector.py
+++ b/postgresql_connector.py
@@ -1,6 +1,6 @@
 # File: postgresql_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/postgresql_connector.py
+++ b/postgresql_connector.py
@@ -93,6 +93,10 @@ class PostgresqlConnector(BaseConnector):
         else:
             other_dict = {}
 
+        other_dict["sslmode"] = "verify-full" if config.get("verify_server_cert", True) else "require"
+        if ssl_root_cert := config.get("ssl_root_cert"):
+            other_dict["sslrootcert"] = ssl_root_cert
+
         try:
             self._connection = psycopg2.connect(user=username, password=password, dbname=database, host=host, **other_dict)
             self._cursor = self._connection.cursor()

--- a/postgresql_consts.py
+++ b/postgresql_consts.py
@@ -1,6 +1,6 @@
 # File: postgresql_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/postgresql_run_query.html
+++ b/postgresql_run_query.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!--  File: postgresql_run_query.html
-  Copyright (c) 2017-2025 Splunk Inc.
+  Copyright (c) 2017-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/postgresql_view.py
+++ b/postgresql_view.py
@@ -1,6 +1,6 @@
 # File: postgresql_view.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Chore: update connector development hooks.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Chore: update connector development hooks.
+* Enforce encrypted PostgreSQL connections and verify the server certificate and hostname by default, with asset settings for certificate verification and the trusted CA file path. Existing assets must trust the server certificate or explicitly disable verification.


### PR DESCRIPTION
Written by Codex for ESPM-5228.

## Summary

- require encrypted PostgreSQL connections
- verify the server certificate and hostname by default with libpq sslmode=verify-full
- add asset settings for the verification opt-out and trusted CA file path
- make the first-class verification setting override a conflicting sslmode in the free-form other parameters

## Tracking

- PAPP: PAPP-38016
- PSAAS: PSAAS-31313
- Provenance: VULN-94038 / FS-2185

## Source-backed validation

PostgreSQL documents that libpq defaults to sslmode=prefer, which first attempts TLS but falls back to plaintext. It recommends verify-full in security-sensitive environments because that mode validates both the certificate chain and server hostname: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION

PostgreSQL also documents sslrootcert as the CA-file connection parameter and ~/.postgresql/root.crt as its default: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT

The attached ticket patch was adapted so the explicit asset security control wins over a conflicting sslmode supplied through other; otherwise an asset could appear to enable verification while silently retaining sslmode=disable or prefer.

## Breaking changes

Existing assets now use sslmode=verify-full by default. They must trust the PostgreSQL server certificate, supply the trusted CA file path, or explicitly disable certificate verification. The opt-out still enforces encrypted-only sslmode=require and never falls back to plaintext.

## Verification

- Docker dependency package hook passed both before and after the functional asset configuration change
- repository-wide lint, formatting, app-linter, semgrep, secret, docs, copyright, notice, release-note, and static-test hooks passed
- python3 -m py_compile postgresql_connector.py
- focused behavioral scenarios passed for the secure default, conflicting free-form sslmode, explicit CA path, and verification opt-out
- both commits have valid GPG signatures
- integration testing deferred to CI / SOAR test infrastructure
